### PR TITLE
rudimentary import/export functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,3 +110,4 @@ celerybeat-schedule
 CondexConfig.py
 .vscode/settings.json
 .idea/*
+index.json

--- a/main.py
+++ b/main.py
@@ -101,6 +101,10 @@ class ConDex(cmd.Cmd):
                 icm.index_gen_command()
             elif command_split[0] == 'stop':
                 icm.index_stop_command()
+            elif command_split[0] == 'export':
+                icm.export_index()
+            elif command_split[0] == 'import':
+                icm.import_index()
             else:
                 logger.warn("Unknown Command")
         else:

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ pkg-resources==0.0.0
 pytz==2017.3
 terminaltables==3.1.0
 vine==1.1.4
+jsonpickle==0.9.5


### PR DESCRIPTION
There's zero error handling here, just a quick and dirty import/export

`index export` will dump the export to index.json
`index import` assumes that index.json exists and is formatted properly

jsonpickle library added to requirements; partially removed minimum check when a coin is added