### PR TITLE
Fix unlocked percentage

### DIFF
--- a/main.py
+++ b/main.py
@@ -68,6 +68,8 @@ class ConDex(cmd.Cmd):
                 scm.show_stats()
             elif command == "index":
                 scm.show_index()
+            elif command == "threshold":
+                scm.show_threshold()
             elif command == "coin":
                 if len(command_split) != 2:
                     sys.stdout.write("coin symbol required\n")

--- a/managers/IndexCommandManager.py
+++ b/managers/IndexCommandManager.py
@@ -46,8 +46,6 @@ class IndexCommandManager:
 
         if locked == "true" or locked == "True":
             lockCoin = True
-        
-
 
         for inCoins in indexedCoins:
 
@@ -96,13 +94,14 @@ class IndexCommandManager:
         indexedCoins = DatabaseManager.get_all_index_coin_models()
         indexedCoin = DatabaseManager.get_index_coin_model(coin.upper())
 
+
         for inCoins in indexedCoins:
-            if inCoins.Ticker != coin.upper():
-                if inCoins.Locked == True:
-                    totalLockedPercentage = totalLockedPercentage + inCoins.DesiredPercentage
-                else:
-                    totalUnlockedCoinsCount = totalUnlockedCoinsCount + 1
-        totalUnlockedPercentage = 100 - totalLockedPercentage
+            if inCoins.Locked == True:
+                totalLockedPercentage = round(totalLockedPercentage + inCoins.DesiredPercentage, 2)
+            else:
+                totalUnlockedCoinsCount = totalUnlockedCoinsCount + 1
+
+        totalUnlockedPercentage = round(100 - totalLockedPercentage, 2)
 
         if len(indexedCoins) > 1:
             if totalUnlockedCoinsCount > 0:
@@ -114,21 +113,20 @@ class IndexCommandManager:
                 if percentage_btc_amount >= CondexConfig.BITTREX_MIN_BTC_TRADE_AMOUNT:
 
                     if float(percentage) > indexedCoin.DesiredPercentage:
-                        if totalUnlockedPercentage > float(percentage):
-
+                        if totalUnlockedPercentage + indexedCoin.DesiredPercentage > float(percentage):
                             if self.coin_supported_check(coin.upper()):
-
                                 percentageToAdd = 0.0
 
                                 if totalUnlockedCoinsCount > 0:
-                                    percentageToAdd = float(indexedCoin.DesiredPercentage-float(percentage))/totalUnlockedCoinsCount
+                                    percentageToAdd = round(float(indexedCoin.DesiredPercentage-float(percentage))/totalUnlockedCoinsCount, 2)
                                 else:
-                                    percentageToAdd = float(indexedCoin.DesiredPercentage-float(percentage))
-
+                                    percentageToAdd = round(float(indexedCoin.DesiredPercentage-float(percentage)), 2)
+                                
+                                
                                 for iCoin in indexedCoins:
                                     if iCoin.Ticker != coin.upper():
                                         if iCoin.Locked != True:
-                                            DatabaseManager.update_index_coin_model(iCoin.Ticker, iCoin.DesiredPercentage-percentageToAdd, iCoin.DistanceFromTarget, iCoin.Locked)
+                                            DatabaseManager.update_index_coin_model(iCoin.Ticker, iCoin.DesiredPercentage+percentageToAdd, iCoin.DistanceFromTarget, iCoin.Locked)
 
                                 if isinstance(float(percentage),(float,int,complex,long)):
                                     if DatabaseManager.update_index_coin_model(coin.upper(), float(percentage), 0.0, lockCoin):

--- a/managers/IndexCommandManager.py
+++ b/managers/IndexCommandManager.py
@@ -217,8 +217,9 @@ class IndexCommandManager:
             if percentage_btc_amount <= CondexConfig.BITTREX_MIN_BTC_TRADE_AMOUNT:
                 logger.error("Desired BTC Threshold Value Too Low - " + str(percentage))
             else:
-                DatabaseManager.update_index_info_model(indexInfo.Active, indexInfo.TotalBTCVal, indexInfo.TotalUSDVal,
-                    round(float(percentage),2), indexInfo.OrderTimeout, indexInfo.OrderRetryAmount,
+                DatabaseManager.update_index_info_model(True, indexInfo.TotalBTCVal, indexInfo.TotalUSDVal,
+                                                        round(float(percentage), 2), indexInfo.OrderTimeout,
+                                                        indexInfo.OrderRetryAmount,
                                                         indexInfo.RebalanceTickSetting)
                 logger.info("Index threshold set to " + str(round(float(percentage),2)))
         else:
@@ -229,8 +230,10 @@ class IndexCommandManager:
         indexInfo = DatabaseManager.get_index_info_model()
 
         if isinstance(int(tickcount),(float,int,complex,int)):
-            DatabaseManager.update_index_info_model(indexInfo.Active, indexInfo.TotalBTCVal, indexInfo.TotalUSDVal,
-                round(float(percentage),2), indexInfo.OrderTimeout, indexInfo.OrderRetryAmount, int(tickcount))
+            DatabaseManager.update_index_info_model(True, indexInfo.TotalBTCVal, indexInfo.TotalUSDVal,
+                                                    indexInfo.BalanceThreshold, indexInfo.OrderTimeout,
+                                                    indexInfo.OrderRetryAmount,
+                                                    int(tickcount))
             logger.info("Index rebalance time set to " + str(tickcount) + " minutes.")
         else:
             logger.warn("Tick count isn't a number")

--- a/managers/IndexCommandManager.py
+++ b/managers/IndexCommandManager.py
@@ -101,8 +101,8 @@ class IndexCommandManager:
                 if inCoins.Locked == True:
                     totalLockedPercentage = totalLockedPercentage + inCoins.DesiredPercentage
                 else:
-                    totalUnlockedPercentage = totalUnlockedPercentage + inCoins.DesiredPercentage
                     totalUnlockedCoinsCount = totalUnlockedCoinsCount + 1
+        totalUnlockedPercentage = 100 - totalLockedPercentage
 
         if len(indexedCoins) > 1:
             if totalUnlockedCoinsCount > 0:

--- a/managers/IndexCommandManager.py
+++ b/managers/IndexCommandManager.py
@@ -396,18 +396,16 @@ class IndexCommandManager:
 
         for inCoins in indexedCoins:
             if inCoins.Locked == True:
-                totalLockedPercentage = totalLockedPercentage + inCoins.DesiredPercentage
+                totalLockedPercentage = round(totalLockedPercentage + inCoins.DesiredPercentage, 2)
             else:
                 totalUnlockedCoinsCount = totalUnlockedCoinsCount + 1
-
-        totalPercentage = totalPercentage + totalLockedPercentage
+        totalPercentage = totalLockedPercentage
         totalUnlockedPercentage = totalUnlockedPercentage - totalLockedPercentage
         averagePercentage = round(totalUnlockedPercentage / totalUnlockedCoinsCount, 2)
 
         logger.info("Setting default allocation to " + str(averagePercentage))
         for inCoins in indexedCoins:
             if inCoins.Locked == False:
-                totalPercentage = totalPercentage + averagePercentage
                 if totalPercentage + averagePercentage > 100:
                    desiredPercentage = 100 - totalPercentage
                 else:

--- a/managers/ShowCommandManager.py
+++ b/managers/ShowCommandManager.py
@@ -102,3 +102,14 @@ class ShowCommandManager:
         for line in  pyGraph.graph('Index Distribution', data=data):
             sys.stdout.write(line + "\n")
         sys.stdout.write("\n")
+
+    def show_threshold(self):
+        indexInfo = DatabaseManager.get_index_info_model()
+        sys.stdout.write("\nCurrent Rebalance Threshold\n")
+
+        summary_table_data = [["Active", "Balance Threshold", "Order Timeout", "Rebalance Tick Setting"]]
+        summary_table_data.append([indexInfo.Active, indexInfo.BalanceThreshold, indexInfo.OrderTimeout, indexInfo.RebalanceTickSetting])
+
+        summary_table = AsciiTable(summary_table_data)
+        sys.stdout.write(summary_table.table)
+        sys.stdout.write("\n")


### PR DESCRIPTION
Fixed bug related to equalweight and update functions.

Previously when increasing an allocation of a locked coin it would also increase the allocation for all Unlocked coins. 