### PR TITLE
Fix unlocked

### DIFF
--- a/managers/IndexCommandManager.py
+++ b/managers/IndexCommandManager.py
@@ -46,8 +46,6 @@ class IndexCommandManager:
 
         if locked == "true" or locked == "True":
             lockCoin = True
-        
-
 
         for inCoins in indexedCoins:
 
@@ -97,12 +95,12 @@ class IndexCommandManager:
         indexedCoin = DatabaseManager.get_index_coin_model(coin.upper())
 
         for inCoins in indexedCoins:
-            if inCoins.Ticker != coin.upper():
-                if inCoins.Locked == True:
-                    totalLockedPercentage = totalLockedPercentage + inCoins.DesiredPercentage
-                else:
-                    totalUnlockedPercentage = totalUnlockedPercentage + inCoins.DesiredPercentage
-                    totalUnlockedCoinsCount = totalUnlockedCoinsCount + 1
+            if inCoins.Locked == True:
+                totalLockedPercentage = round(totalLockedPercentage + inCoins.DesiredPercentage, 2)
+            else:
+                totalUnlockedCoinsCount = totalUnlockedCoinsCount + 1
+
+        totalUnlockedPercentage = round(100 - totalLockedPercentage, 2)
 
         if len(indexedCoins) > 1:
             if totalUnlockedCoinsCount > 0:
@@ -114,21 +112,21 @@ class IndexCommandManager:
                 if percentage_btc_amount >= CondexConfig.BITTREX_MIN_BTC_TRADE_AMOUNT:
 
                     if float(percentage) > indexedCoin.DesiredPercentage:
-                        if totalUnlockedPercentage > float(percentage):
-
+                        if totalUnlockedPercentage + indexedCoin.DesiredPercentage > float(percentage):
                             if self.coin_supported_check(coin.upper()):
 
                                 percentageToAdd = 0.0
 
                                 if totalUnlockedCoinsCount > 0:
-                                    percentageToAdd = float(indexedCoin.DesiredPercentage-float(percentage))/totalUnlockedCoinsCount
+                                    percentageToAdd = round(float(indexedCoin.DesiredPercentage-float(percentage))/totalUnlockedCoinsCount, 2)
                                 else:
-                                    percentageToAdd = float(indexedCoin.DesiredPercentage-float(percentage))
+                                    percentageToAdd = round(float(indexedCoin.DesiredPercentage-float(percentage)), 2)
+
 
                                 for iCoin in indexedCoins:
                                     if iCoin.Ticker != coin.upper():
                                         if iCoin.Locked != True:
-                                            DatabaseManager.update_index_coin_model(iCoin.Ticker, iCoin.DesiredPercentage-percentageToAdd, iCoin.DistanceFromTarget, iCoin.Locked)
+                                            DatabaseManager.update_index_coin_model(iCoin.Ticker, iCoin.DesiredPercentage+percentageToAdd, iCoin.DistanceFromTarget, iCoin.Locked)
 
                                 if isinstance(float(percentage),(float,int,complex,long)):
                                     if DatabaseManager.update_index_coin_model(coin.upper(), float(percentage), 0.0, lockCoin):

--- a/managers/IndexCommandManager.py
+++ b/managers/IndexCommandManager.py
@@ -94,6 +94,7 @@ class IndexCommandManager:
         indexedCoins = DatabaseManager.get_all_index_coin_models()
         indexedCoin = DatabaseManager.get_index_coin_model(coin.upper())
 
+
         for inCoins in indexedCoins:
             if inCoins.Locked == True:
                 totalLockedPercentage = round(totalLockedPercentage + inCoins.DesiredPercentage, 2)
@@ -114,7 +115,6 @@ class IndexCommandManager:
                     if float(percentage) > indexedCoin.DesiredPercentage:
                         if totalUnlockedPercentage + indexedCoin.DesiredPercentage > float(percentage):
                             if self.coin_supported_check(coin.upper()):
-
                                 percentageToAdd = 0.0
 
                                 if totalUnlockedCoinsCount > 0:
@@ -394,18 +394,16 @@ class IndexCommandManager:
 
         for inCoins in indexedCoins:
             if inCoins.Locked == True:
-                totalLockedPercentage = totalLockedPercentage + inCoins.DesiredPercentage
+                totalLockedPercentage = round(totalLockedPercentage + inCoins.DesiredPercentage, 2)
             else:
                 totalUnlockedCoinsCount = totalUnlockedCoinsCount + 1
-
-        totalPercentage = totalPercentage + totalLockedPercentage
+        totalPercentage = totalLockedPercentage
         totalUnlockedPercentage = totalUnlockedPercentage - totalLockedPercentage
         averagePercentage = round(totalUnlockedPercentage / totalUnlockedCoinsCount, 2)
 
         logger.info("Setting default allocation to " + str(averagePercentage))
         for inCoins in indexedCoins:
             if inCoins.Locked == False:
-                totalPercentage = totalPercentage + averagePercentage
                 if totalPercentage + averagePercentage > 100:
                    desiredPercentage = 100 - totalPercentage
                 else:


### PR DESCRIPTION
Fixed bug related to equalweight and update functions.

Previously when increasing an allocation of a locked coin it would also increase the allocation for all Unlocked coins instead of decreasing the allocation.  

Fixed equal weight issue that resulted in last coin getting 0%.